### PR TITLE
Port to OCaml 5.5 (compiler-libs / merlin-lib AST)

### DIFF
--- a/lib/file_view.ml
+++ b/lib/file_view.ml
@@ -968,30 +968,38 @@ end
 module Type_view = struct
   type t = Typed_types.type_expr
 
-  let arrow ct =
+  (* OCaml 5.5 wraps function argument types in [Tpoly (_, [])] even when no
+     polymorphism is present. Peel those identity wrappers so the leaf
+     inspectors below see the underlying [Tconstr]/[Tarrow]/etc. *)
+  let rec desc ct =
     match Typed_types.get_desc ct with
+    | Typed_types.Tpoly (body, _) -> desc body
+    | d -> d
+
+  let arrow ct =
+    match desc ct with
     | Typed_types.Tarrow (label, dom, ret, _) -> Some (label, dom, ret)
     | _ -> None
 
   let is_function (ct : t) = Option.is_some (arrow ct)
 
   let is_variable ct =
-    match Typed_types.get_desc ct with
+    match desc ct with
     | Typed_types.Tvar _ | Typed_types.Tunivar _ -> true
     | _ -> false
 
   let tuple ct =
-    match Typed_types.get_desc ct with
+    match desc ct with
     | Typed_types.Ttuple fields -> Some (List.map snd fields)
     | _ -> None
 
   let constr ct =
-    match Typed_types.get_desc ct with
+    match desc ct with
     | Typed_types.Tconstr (path, args, _) -> Some (name_of_path path, args)
     | _ -> None
 
   let constr_path ct =
-    match Typed_types.get_desc ct with
+    match desc ct with
     | Typed_types.Tconstr (path, _, _) -> Some path
     | _ -> None
 
@@ -1042,12 +1050,12 @@ module Type_view = struct
     | _ -> false
 
   let rec return_type (ct : t) : t option =
-    match Typed_types.get_desc ct with
+    match desc ct with
     | Typed_types.Tarrow (_, _, ret, _) -> return_type ret
     | _ -> Some ct
 
   let rec returns_option (ct : t) =
-    match Typed_types.get_desc ct with
+    match desc ct with
     | Typed_types.Tarrow (_, _, ret, _) -> returns_option ret
     | Typed_types.Tconstr (path, _, _) ->
         Typed_path.same path Typed_predef.path_option
@@ -1057,7 +1065,7 @@ module Type_view = struct
 
   let count_unlabelled (ct : t) ~match_ =
     let rec aux acc (ct : t) =
-      match Typed_types.get_desc ct with
+      match desc ct with
       | Typed_types.Tarrow (Asttypes.Nolabel, dom, rest, _) ->
           let acc = if match_ dom then acc + 1 else acc in
           aux acc rest

--- a/lib/file_view.ml
+++ b/lib/file_view.ml
@@ -291,7 +291,7 @@ let typed_expr_callee_name (expr : Typedtree.expression) =
     | Texp_ident (path, _, _) -> Some (name_of_path path)
     | Texp_apply (fn, _) -> aux fn
     | Texp_construct (lid, _, _) -> Some (name_of_longident lid.txt)
-    | Texp_open (_, body) -> aux body
+    | Texp_struct_item (_, body) -> aux body
     | _ -> None
   in
   aux expr
@@ -339,7 +339,7 @@ let rec is_silent_accept (expr : Typedtree.expression) =
       | "Ok" | "()" -> true
       | _ -> false)
   | Texp_tuple _ | Texp_record _ | Texp_ident _ -> true
-  | Texp_let (_, _, body) | Texp_open (_, body) | Texp_sequence (_, body) ->
+  | Texp_let (_, _, body) | Texp_struct_item (_, body) | Texp_sequence (_, body) ->
       is_silent_accept body
   | Texp_ifthenelse (_, a, Some b) -> is_silent_accept a && is_silent_accept b
   | Texp_match (_, comp_cases, value_cases, _) ->
@@ -662,7 +662,7 @@ let typed_type_children (decl : Typedtree.type_declaration) =
             ~deprecated:(typed_has_deprecated cd.cd_attributes)
             cd.cd_loc)
         constructors
-  | Ttype_abstract | Ttype_open -> []
+  | Ttype_abstract | Ttype_open | Ttype_external _ -> []
 
 let typed_type_item (decl : Typedtree.type_declaration) =
   typed_item ~name:decl.typ_name.txt ~kind:Type

--- a/lib/function_metrics.ml
+++ b/lib/function_metrics.ml
@@ -68,7 +68,7 @@ let rec callee_parts expr =
   match expr.T.exp_desc with
   | Texp_ident (path, _, _) -> Some (path_parts path)
   | Texp_apply (fn, _) -> callee_parts fn
-  | Texp_open (_, inner) -> callee_parts inner
+  | Texp_struct_item (_, inner) -> callee_parts inner
   | _ -> None
 
 let is_boolean_operator expr =
@@ -83,7 +83,7 @@ let is_boolean_operator expr =
 let rec is_function_expr expr =
   match expr.T.exp_desc with
   | Texp_function _ -> true
-  | Texp_open (_, inner) -> is_function_expr inner
+  | Texp_struct_item (_, inner) -> is_function_expr inner
   | _ -> false
 
 let rec analyze_expr expr =
@@ -131,9 +131,7 @@ let rec analyze_expr expr =
   | Texp_atomic_loc (expr, _, _)
   | Texp_field (expr, _, _)
   | Texp_lazy expr
-  | Texp_assert (expr, _)
-  | Texp_open (_, expr)
-  | Texp_letexception (_, expr) ->
+  | Texp_assert (expr, _) ->
       analyze_expr expr
   | Texp_setfield (record, _, _, value) ->
       merge (analyze_expr record) (analyze_expr value)
@@ -143,7 +141,7 @@ let rec analyze_expr expr =
   | Texp_for (_, _, first, last, _, body) ->
       merge (decision ~loops:1 1)
         (sum [ analyze_expr first; analyze_expr last; analyze_expr body ])
-  | Texp_letmodule (_, _, _, _, body) -> analyze_expr body
+  | Texp_struct_item (_, body) -> analyze_expr body
   | Texp_letop { let_; ands; body; _ } ->
       let binding_count = 1 + List.length ands in
       let binding_exprs =
@@ -278,9 +276,7 @@ let rec count_match_cases_expr expr =
   | Texp_atomic_loc (expr, _, _)
   | Texp_field (expr, _, _)
   | Texp_lazy expr
-  | Texp_assert (expr, _)
-  | Texp_open (_, expr)
-  | Texp_letexception (_, expr) ->
+  | Texp_assert (expr, _) ->
       count_match_cases_expr expr
   | Texp_setfield (record, _, _, value) ->
       count_match_cases_expr record + count_match_cases_expr value
@@ -290,8 +286,9 @@ let rec count_match_cases_expr expr =
       count_match_cases_expr first
       + count_match_cases_expr last
       + count_match_cases_expr body
-  | Texp_letmodule (_, _, _, module_expr, body) ->
-      count_match_cases_module_expr module_expr + count_match_cases_expr body
+  | Texp_struct_item ({ str_desc = Tstr_module mb; _ }, body) ->
+      count_match_cases_module_expr mb.mb_expr + count_match_cases_expr body
+  | Texp_struct_item (_, expr) -> count_match_cases_expr expr
   | Texp_letop { let_; ands; body; _ } ->
       count_match_cases_expr let_.bop_exp
       + List.fold_left
@@ -390,7 +387,7 @@ and trailing_record_fields_expr expr =
   | Texp_try (expr, _, _) -> trailing_record_fields_expr expr
   | Texp_function ([], T.Tfunction_body body) ->
       trailing_record_fields_expr body
-  | Texp_open (_, body) -> trailing_record_fields_expr body
+  | Texp_struct_item (_, body) -> trailing_record_fields_expr body
   | Texp_construct (_, _, [ expr ]) | Texp_variant (_, Some expr) ->
       trailing_record_fields_expr expr
   | _ -> 0
@@ -488,17 +485,16 @@ let rec depth_expr ~in_closure current_depth expr =
   | Texp_field (expr, _, _)
   | Texp_lazy expr
   | Texp_assert (expr, _)
-  | Texp_open (_, expr)
-  | Texp_letexception (_, expr)
   | Texp_send (expr, _)
   | Texp_pack { mod_desc = Tmod_unpack (expr, _); _ } ->
       depth_expr ~in_closure current_depth expr
   | Texp_setfield (record, _, _, value) ->
       depth_pair ~in_closure current_depth record value
-  | Texp_letmodule (_, _, _, module_expr, body) ->
+  | Texp_struct_item ({ str_desc = Tstr_module mb; _ }, body) ->
       max
-        (depth_module_expr ~in_closure current_depth module_expr)
+        (depth_module_expr ~in_closure current_depth mb.mb_expr)
         (depth_expr ~in_closure current_depth body)
+  | Texp_struct_item (_, expr) -> depth_expr ~in_closure current_depth expr
   | Texp_letop { let_; ands; body; _ } ->
       depth_letop ~in_closure current_depth let_ ands body
   | Texp_variant (_, arg) -> (

--- a/lib/rules/e600.ml
+++ b/lib/rules/e600.ml
@@ -37,7 +37,7 @@ let rec is_list_expr (expr : T.expression) =
   match expr.exp_desc with
   | Texp_construct (lid, _, _) ->
       List.mem (Ocaml_parsing.Longident.flatten lid.txt) [ [ "[]" ]; [ "::" ] ]
-  | Texp_open (_, expr) -> is_list_expr expr
+  | Texp_struct_item (_, expr) -> is_list_expr expr
   | _ -> false
 
 let binding_defines_tests (vb : T.value_binding) =

--- a/lib/rules/query.ml
+++ b/lib/rules/query.ml
@@ -33,7 +33,7 @@ module Expr = struct
     | Texp_ident (path, _, _) -> Some (Path.parts path)
     | Texp_apply (fn, _) -> callee_parts fn
     | Texp_construct (lid, _, _) -> Some (Longident.parts lid.txt)
-    | Texp_open (_, inner) -> callee_parts inner
+    | Texp_struct_item (_, inner) -> callee_parts inner
     | _ -> None
 
   let callee_ends_with expr suffix =
@@ -45,9 +45,9 @@ module Expr = struct
     match expr.T.exp_desc with
     | Texp_apply ({ exp_desc = Texp_ident (path, _, _); _ }, _) ->
         Path.ends_with path suffix
-    | Texp_apply ({ exp_desc = Texp_open (_, inner); _ }, _) ->
+    | Texp_apply ({ exp_desc = Texp_struct_item (_, inner); _ }, _) ->
         calls inner suffix
-    | Texp_open (_, inner) -> calls inner suffix
+    | Texp_struct_item (_, inner) -> calls inner suffix
     | _ -> false
 
   let positional_args args =

--- a/lib/rules/suite.ml
+++ b/lib/rules/suite.ml
@@ -7,7 +7,7 @@ let rec is_empty_list (expr : T.expression) =
   match expr.exp_desc with
   | Texp_construct (lid, _, []) ->
       Ocaml_parsing.Longident.flatten lid.txt = [ "[]" ]
-  | Texp_open (_, inner) -> is_empty_list inner
+  | Texp_struct_item (_, inner) -> is_empty_list inner
   | _ -> false
 
 let string_constant (expr : T.expression) =

--- a/lib/type_kind.ml
+++ b/lib/type_kind.ml
@@ -66,7 +66,7 @@ let decl_member_types (td : Types.type_declaration) =
           | Types.Cstr_record labels ->
               List.map (fun (l : Types.label_declaration) -> l.ld_type) labels)
         cstrs
-  | Types.Type_abstract _ | Types.Type_open -> (
+  | Types.Type_abstract _ | Types.Type_open | Types.Type_external _ -> (
       match td.type_manifest with Some ty -> [ ty ] | None -> [])
 
 (* A private type still exposes its representation (you may read it, only not


### PR DESCRIPTION
## Port merlint to OCaml 5.5 (compiler-libs / merlin-lib AST)

OCaml 5.5 changed the typed AST that merlin-lib re-exports, so merlint's `lib/`
does not compile against `merlin-lib` for 5.5. This PR makes `lib/` + `bin/`
build and all unit tests pass on `ocaml-base-compiler.5.5.0` with
`merlin-lib.5.8-505`.

### Changes

**1. `Texp_open` → `Texp_struct_item` (commit 1)**
OCaml 5.5 unified `Texp_open`, `Texp_letmodule` and `Texp_letexception` into a
single `Texp_struct_item of structure_item * expression`. Every site that looked
through a local open/module/exception to the inner expression now matches
`Texp_struct_item`. Where the old code also descended into the bound module
expression (`count_match_cases_expr`, `depth_expr`), that is preserved via
`Texp_struct_item ({ str_desc = Tstr_module mb; _ }, body)` and `mb.mb_expr`.

`Types.type_kind` gained `Type_external` and `Typedtree` gained
`Ttype_external`; both expose no members, so they join the existing
abstract/open arms in `type_kind.ml` and `file_view.ml`.

Files: `lib/function_metrics.ml`, `lib/file_view.ml`, `lib/type_kind.ml`,
`lib/rules/{query,suite,e600}.ml`.

**2. Peel 5.5 `Tpoly` wrappers in `Type_view` (commit 2)**
OCaml 5.5 wraps function *argument* types in an identity `Tpoly (ty, [])` even
when there is no polymorphism. `Type_view`'s leaf inspectors matched
`Tconstr`/`Tarrow`/`Ttuple` directly via `get_desc`, so `is_bool` / `is_string`
silently returned `false` on a `bool` / `string` argument. This broke
type-driven rules without any compile error — e.g. **E350** (boolean blindness)
found 0 boolean parameters and **E333** (`_of_` vs `_to_`) could not resolve a
`string` source type. Fixed with a `desc` helper that peels `Tpoly` before the
leaf inspectors. `constrs` already handled `Tpoly` and is unchanged.

This one is worth a careful look: it is a *silent* behavioural regression on
5.5, not a build break, and is the kind of thing that would quietly weaken the
linter on the new compiler.

### Validation
- `dune build` (lib + bin + tests + docs): clean on 5.5.0.
- `dune runtest`: 152 unit tests pass; E350/E333 cram tests restored by commit 2.
- Built `merlint` run against a real 5.5 project end-to-end (JSON report).

### Open question — version strategy (why this is a draft)

merlint binds merlin-lib's `Ocaml_typing.Typedtree` constructors directly, with
no `cppo` and no per-version branches, so **a given merlint revision is fixed to
one compiler/merlin-lib generation**. These changes are the "5.5 backend": they
will *not* compile on ≤ 5.4 (`Texp_struct_item` / `Type_external` don't exist
there; `Texp_open` does).

merlin itself solves this with **a branch per OCaml version** (a shared frontend,
a version-specific AST backend), rather than `cppo`. This PR follows that model:
a straight port suitable for `master` moving to 5.5, or a `505` branch.

I'm happy to instead provide a **`cppo`-guarded** version that keeps a single
branch building on both 5.4 and 5.5 (`#if OCAML_VERSION >= (5,5,0)` around the
~8 AST sites + the two new type-kind arms), if you'd prefer single-branch
multi-version support. Let me know which fits merlint's release model and I'll
finalise.

> Note: the canonical repo is tangled.org; this PR is against the GitHub mirror
> for convenience — point me at the right place if you take patches elsewhere.

---
🤖 Drafted with AI assistance; reviewed and validated by a human on 5.5.0.
